### PR TITLE
Added macro-enabled word doc as allowed mime type

### DIFF
--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/SpeechDropApplication.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/SpeechDropApplication.java
@@ -41,6 +41,7 @@ public class SpeechDropApplication {
     public static final List<String> allowedMimeTypes = Arrays.asList(
             "application/msword", // doc
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // docx
+            "application/vnd.ms-word.document.macroEnabled.12", //macro-enbaled doc
             "application/vnd.oasis.opendocument.text", // odt
             "application/x-iwork-pages-sffpages", // pages
             "application/pdf", // pdf


### PR DESCRIPTION
Hey, some of us who use this in NFA-LD have been having an issue with uploading docs from a Mac. I took a look and I think its because verbatimized word docs save with the macros enabled on Mac, so I added it as an allowed mime type to hopefully fix that issue. Thanks! - Jflick58