### PR TITLE
Increase proxy read timeout

### DIFF
--- a/nginx/example_config
+++ b/nginx/example_config
@@ -25,7 +25,7 @@ server {
       proxy_http_version 1.1;
       proxy_pass http://127.0.0.1:6901/sock/;
       proxy_buffering off;
-      proxy_read_timeout 3600;
+      proxy_read_timeout 4200;
 
       proxy_set_header Host $host:$server_port;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Not sure if the loading bottleneck is with the web server loading or local internet connection (based on my tests it’s unlikely to be the latter). If the web server is struggling to respond, Ngnix could be the one sending the timeout.  Up to you, but I would try to increase the timeout to see if it helps.