### PR TITLE
Add GitHub Action to build Maven JAR on PRs

### DIFF
--- a/.github/workflows/jar-build.yml
+++ b/.github/workflows/jar-build.yml
@@ -1,0 +1,24 @@
+name: Build JAR
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Maven project
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+
+      - name: Build JAR
+        run: mvn -B -ntp package -DskipTests

--- a/.github/workflows/jar-build.yml
+++ b/.github/workflows/jar-build.yml
@@ -21,4 +21,4 @@ jobs:
           cache: maven
 
       - name: Build JAR
-        run: mvn -B -ntp package -DskipTests
+        run: mvn -B -ntp package


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Maven project for pull requests using Temurin JDK 8

## Testing
- mvn -B -ntp package -DskipTests *(fails: network unreachable when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a3eddf9c8322a02bbe291fbc3071