### PR TITLE
Upload built JAR as workflow artifact

### DIFF
--- a/.github/workflows/jar-build.yml
+++ b/.github/workflows/jar-build.yml
@@ -24,3 +24,10 @@ jobs:
 
       - name: Build JAR
         run: mvn -B -ntp package
+
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: speechdrop-jar
+          path: target/*.jar
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- ensure the jar-build workflow uploads the Maven-built JAR as a downloadable artifact

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2aa6ba86c8322bc86ac6e00dcdf8a