### PR TITLE
Update JUL formatter to include thrown placeholder

### DIFF
--- a/src/main/resources/vertx-default-jul-logging.properties
+++ b/src/main/resources/vertx-default-jul-logging.properties
@@ -1,3 +1,3 @@
 handlers=java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=%1$tH:%1$tM:%1$tS [%4$s] %5$s%n
+java.util.logging.SimpleFormatter.format=%1$tH:%1$tM:%1$tS [%4$s] %5$s%6$s%n


### PR DESCRIPTION
## Summary
- append the `%6$s` placeholder to the JUL simple formatter so logged exceptions include their stack traces

## Testing
- mvn -ntp test *(fails: unable to resolve dependencies without network access)*
- journalctl -u speechdrop | tail *(fails: no journal files available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bb0660f88322b04b60c1e1ac25f2