### PR TITLE
Remove CopyWebpackPlugin and set room title client-side

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,6 @@
         "@vue/compiler-sfc": "^3.4.30",
         "babel-loader": "^9.1.3",
         "clean-webpack-plugin": "^4.0.0",
-        "copy-webpack-plugin": "^13.0.1",
         "css-loader": "^6.10.0",
         "dropzone": "^4.3.0",
         "html-webpack-plugin": "^5.6.4",

--- a/frontend/src/html/about.html
+++ b/frontend/src/html/about.html
@@ -14,7 +14,6 @@
         ga('send', 'pageview');
     </script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,600">
-    <link rel="icon" href="/static/img/sd-favicon.png">
 </head>
 <body>
 <nav>

--- a/frontend/src/html/main.html
+++ b/frontend/src/html/main.html
@@ -15,7 +15,6 @@
         ga('send', 'pageview');
     </script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,600">
-    <link rel="icon" href="/static/img/sd-favicon.png">
 </head>
 <body>
 <a href="https://github.com/yunyu/speechdrop" class="github-corner" aria-label="View source on Github">

--- a/frontend/src/html/room.html
+++ b/frontend/src/html/room.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>{% ROOM_NAME %} | SpeechDrop</title>
+    <title>SpeechDrop</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -14,7 +14,6 @@
         ga('send', 'pageview');
     </script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,600">
-    <link rel="icon" href="/static/img/sd-favicon.png">
 </head>
 <body>
 <nav>

--- a/frontend/src/js/RoomContainer.vue
+++ b/frontend/src/js/RoomContainer.vue
@@ -9,7 +9,7 @@
             download
         >
             <img
-                src="/static/img/download-folder.svg"
+                :src="downloadFolderIcon"
                 class="header-button-img"
                 alt="Download icon"
             />
@@ -31,7 +31,7 @@
                 <div id="file-dropzone">
                     <img
                         class="passthrough-pointer"
-                        src="/static/img/upload-icon.svg"
+                        :src="uploadIcon"
                         width="80"
                         height="80"
                         alt="Upload icon"
@@ -85,6 +85,9 @@ import Dropzone from 'dropzone';
 import Cookies from 'js-cookie';
 import EventBus from 'vertx3-eventbus-client';
 
+import downloadFolderIcon from '../static/img/download-folder.svg';
+import uploadIcon from '../static/img/upload-icon.svg';
+
 Dropzone.autoDiscover = false;
 
 const roomConfig = window.roomConfig || {};
@@ -106,7 +109,9 @@ export default {
             mediaUrl: roomConfig.mediaUrl || '',
             allowedMimes: allowedMimes || '',
             prevFilesJson: JSON.stringify(initialFiles),
-            _onKeydown: null
+            _onKeydown: null,
+            downloadFolderIcon,
+            uploadIcon
         };
     },
     mounted() {

--- a/frontend/src/js/room.js
+++ b/frontend/src/js/room.js
@@ -5,4 +5,16 @@ import { createApp } from 'vue';
 
 import RoomContainer from './RoomContainer.vue';
 
+const roomConfig = window.roomConfig || {};
+
+if (typeof document !== 'undefined') {
+    const roomName = roomConfig.roomName;
+    if (roomName) {
+        const textarea = document.createElement('textarea');
+        textarea.innerHTML = roomName;
+        const decodedRoomName = textarea.value;
+        document.title = `${decodedRoomName} | SpeechDrop`;
+    }
+}
+
 createApp(RoomContainer).mount('#room-container');

--- a/frontend/src/scss/room.scss
+++ b/frontend/src/scss/room.scss
@@ -31,7 +31,7 @@
 
 .file-header {
     height: 149px;
-    background: url('/static/img/doc-bg.svg') no-repeat right bottom;
+    background: url('../static/img/doc-bg.svg') no-repeat right bottom;
     background-size: 100px 95px;
     overflow-y: auto;
 }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,10 +1,11 @@
 const path = require('path');
 const webpack = require('webpack');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { VueLoaderPlugin } = require('vue-loader');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const faviconPath = path.resolve(__dirname, 'src/static/img/sd-favicon.png');
 
 const pages = [
     { name: 'main', template: 'main.html', chunks: ['commons', 'main'] },
@@ -50,12 +51,7 @@ module.exports = {
                 test: /\.scss$/,
                 use: [
                     MiniCssExtractPlugin.loader,
-                    {
-                        loader: 'css-loader',
-                        options: {
-                            url: false
-                        }
-                    },
+                    'css-loader',
                     {
                         loader: 'sass-loader',
                         options: {
@@ -63,6 +59,13 @@ module.exports = {
                         }
                     }
                 ]
+            },
+            {
+                test: /\.(png|svg)$/i,
+                type: 'asset/resource',
+                generator: {
+                    filename: 'static/img/[name].[contenthash][ext]'
+                }
             }
         ]
     },
@@ -86,15 +89,6 @@ module.exports = {
     },
     plugins: [
         new CleanWebpackPlugin(),
-        new CopyWebpackPlugin({
-            patterns: [
-                {
-                    from: path.resolve(__dirname, 'src/static'),
-                    to: 'static',
-                    noErrorOnMissing: true
-                }
-            ]
-        }),
         new webpack.DefinePlugin({
             __VUE_OPTIONS_API__: true,
             __VUE_PROD_DEVTOOLS__: false
@@ -110,7 +104,8 @@ module.exports = {
                     template: path.resolve(__dirname, `src/html/${page.template}`),
                     chunks: page.chunks,
                     inject: 'body',
-                    scriptLoading: 'defer'
+                    scriptLoading: 'defer',
+                    favicon: faviconPath
                 })
         )
     ]

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1382,17 +1382,6 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-copy-webpack-plugin@^13.0.1:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-13.0.1.tgz#fba18c22bcab3633524e1b652580ff4489eddc0d"
-  integrity sha512-J+YV3WfhY6W/Xf9h+J1znYuqTye2xkBUIGyTPWuBAT27qajBa5mR4f8WBmfDY3YjRftT2kqZZiLi1qf0H+UOFw==
-  dependencies:
-    glob-parent "^6.0.1"
-    normalize-path "^3.0.0"
-    schema-utils "^4.2.0"
-    serialize-javascript "^6.0.2"
-    tinyglobby "^0.2.12"
-
 core-js-compat@^3.43.0:
   version "3.45.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.45.1.tgz#424f3f4af30bf676fd1b67a579465104f64e9c7a"

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/SpeechDropApplication.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/SpeechDropApplication.java
@@ -241,7 +241,6 @@ public class SpeechDropApplication {
 
                     ctx.response().putHeader(CONTENT_TYPE, TEXT_HTML).end(
                             roomTemplate
-                                    .replace("{% ROOM_NAME %}", escapedRoomName)
                                     .replace("{% ROOM_CONFIG %}", configPayload.encode())
                     );
                 });


### PR DESCRIPTION
## Summary
- set a static room page title in HTML and update it from room.js using the decoded room config value
- remove CopyWebpackPlugin in favor of webpack asset modules and import the room icons directly from Vue/Sass
- configure HtmlWebpackPlugin to emit the favicon and rely on the build output to keep the inline roomConfig script ahead of the deferred bundles

## Testing
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68d2f86a3edc83229f048397b842b15a