### PR TITLE
Migrate backend to Vert.x 4 and JDK 17

### DIFF
--- a/.github/workflows/jar-build.yml
+++ b/.github/workflows/jar-build.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 8
+      - name: Set up Temurin JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '8'
+          java-version: '17'
           cache: maven
 
       - name: Build JAR

--- a/.github/workflows/jar-build.yml
+++ b/.github/workflows/jar-build.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 17
+      - name: Set up Temurin JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: maven
 
       - name: Build JAR

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
         <frontend.directory>frontend</frontend.directory>
         <vertx.verticle>edu.vanderbilt.yunyulin.speechdrop.SpeechDropVerticle</vertx.verticle>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.testSource>17</maven.compiler.testSource>
-        <maven.compiler.testTarget>17</maven.compiler.testTarget>
-        <vertx.version>4.5.9</vertx.version>
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.testSource>21</maven.compiler.testSource>
+        <maven.compiler.testTarget>21</maven.compiler.testTarget>
+        <vertx.version>5.0.4</vertx.version>
     </properties>
 
     <build>
@@ -125,6 +125,10 @@
             <artifactId>lombok</artifactId>
             <version>1.18.42</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,12 @@
         <frontend.directory>frontend</frontend.directory>
         <vertx.verticle>edu.vanderbilt.yunyulin.speechdrop.SpeechDropVerticle</vertx.verticle>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.testSource>1.8</maven.compiler.testSource>
-        <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.testSource>17</maven.compiler.testSource>
+        <maven.compiler.testTarget>17</maven.compiler.testTarget>
+        <vertx.version>4.5.9</vertx.version>
     </properties>
 
     <build>
@@ -89,7 +91,7 @@
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-stack-depchain</artifactId>
-                <version>3.9.16</version>
+                <version>${vertx.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -104,6 +106,14 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/Broadcaster.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/Broadcaster.java
@@ -7,7 +7,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.bridge.BridgeEventType;
 import io.vertx.ext.bridge.PermittedOptions;
-import io.vertx.ext.web.handler.sockjs.BridgeOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions;
 import io.vertx.ext.web.handler.sockjs.SockJSHandler;
 
 import static edu.vanderbilt.yunyulin.speechdrop.SpeechDropApplication.LOGGER;
@@ -21,14 +21,14 @@ public class Broadcaster {
     public Broadcaster(Vertx vertx, RoomHandler roomHandler) {
         this.vertx = vertx;
         this.sockJSHandler = SockJSHandler.create(vertx);
-        sockJSHandler.bridge(new BridgeOptions().addOutboundPermitted(
+        sockJSHandler.bridge(new SockJSBridgeOptions().addOutboundPermitted(
                 new PermittedOptions().setAddressRegex("speechdrop\\.room\\..+")
         ), be -> {
             if (be.type() == BridgeEventType.REGISTER) {
                 String address = be.getRawMessage().getString("address");
                 String roomId = getRoomId(address);
                 if (roomId != null && roomHandler.roomExists(roomId)) {
-                    roomHandler.getRoom(roomId).getIndex().setHandler(ar -> {
+                    roomHandler.getRoom(roomId).getIndex().onComplete(ar -> {
                         // Copies envelope structure from EventBusBridgeImpl##deliverMessage
                         be.socket().write(Buffer.buffer(new JsonObject()
                                 .put("type", "rec")

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/Broadcaster.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/Broadcaster.java
@@ -7,6 +7,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.bridge.BridgeEventType;
 import io.vertx.ext.bridge.PermittedOptions;
+import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions;
 import io.vertx.ext.web.handler.sockjs.SockJSHandler;
 
@@ -15,28 +16,32 @@ import static edu.vanderbilt.yunyulin.speechdrop.SpeechDropApplication.LOGGER;
 public class Broadcaster {
     private final Vertx vertx;
     private final SockJSHandler sockJSHandler;
+    private final Router sockJSRouter;
 
     private static final String ADDR_PREFIX = "speechdrop.room.";
 
     public Broadcaster(Vertx vertx, RoomHandler roomHandler) {
         this.vertx = vertx;
         this.sockJSHandler = SockJSHandler.create(vertx);
-        sockJSHandler.bridge(new SockJSBridgeOptions().addOutboundPermitted(
+        this.sockJSRouter = sockJSHandler.bridge(new SockJSBridgeOptions().addOutboundPermitted(
                 new PermittedOptions().setAddressRegex("speechdrop\\.room\\..+")
         ), be -> {
             if (be.type() == BridgeEventType.REGISTER) {
                 String address = be.getRawMessage().getString("address");
                 String roomId = getRoomId(address);
                 if (roomId != null && roomHandler.roomExists(roomId)) {
-                    roomHandler.getRoom(roomId).getIndex(index -> {
-                        // Copies envelope structure from EventBusBridgeImpl##deliverMessage
-                        be.socket().write(Buffer.buffer(new JsonObject()
-                                .put("type", "rec")
-                                .put("address", address)
-                                .put("body", index)
-                                .encode()
-                        ));
-                    });
+                    roomHandler.getRoom(roomId).getIndex()
+                            .onSuccess(index -> {
+                                // Copies envelope structure from EventBusBridgeImpl##deliverMessage
+                                be.socket().write(Buffer.buffer(new JsonObject()
+                                        .put("type", "rec")
+                                        .put("address", address)
+                                        .put("body", index)
+                                        .encode()
+                                ));
+                                be.complete(true);
+                            })
+                            .onFailure(err -> be.complete(false));
                     return;
                 } else {
                     be.complete(false);
@@ -62,8 +67,8 @@ public class Broadcaster {
         }
     }
 
-    public SockJSHandler getSockJSHandler() {
-        return sockJSHandler;
+    public Router getSockJSRouter() {
+        return sockJSRouter;
     }
 
     public void publishUpdate(String room, String data) {

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/Broadcaster.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/Broadcaster.java
@@ -29,19 +29,13 @@ public class Broadcaster {
                 String roomId = getRoomId(address);
                 if (roomId != null && roomHandler.roomExists(roomId)) {
                     roomHandler.getRoom(roomId).getIndex().onComplete(ar -> {
-                        if (ar.succeeded()) {
-                            // Copies envelope structure from EventBusBridgeImpl##deliverMessage
-                            be.socket().write(Buffer.buffer(new JsonObject()
-                                    .put("type", "rec")
-                                    .put("address", address)
-                                    .put("body", ar.result())
-                                    .encode()
-                            ));
-                            be.complete(true);
-                        } else {
-                            LOGGER.error("Failed to deliver initial index for room " + roomId, ar.cause());
-                            be.complete(false);
-                        }
+                        // Copies envelope structure from EventBusBridgeImpl##deliverMessage
+                        be.socket().write(Buffer.buffer(new JsonObject()
+                                .put("type", "rec")
+                                .put("address", address)
+                                .put("body", ar.result())
+                                .encode()
+                        ));
                     });
                     return;
                 } else {

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/Broadcaster.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/Broadcaster.java
@@ -28,7 +28,7 @@ public class Broadcaster {
                 String address = be.getRawMessage().getString("address");
                 String roomId = getRoomId(address);
                 if (roomId != null && roomHandler.roomExists(roomId)) {
-                    roomHandler.getRoom(roomId).getIndex().onComplete(ar -> {
+                    roomHandler.getRoom(roomId).getIndex().future().onComplete(ar -> {
                         // Copies envelope structure from EventBusBridgeImpl##deliverMessage
                         be.socket().write(Buffer.buffer(new JsonObject()
                                 .put("type", "rec")

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/Broadcaster.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/Broadcaster.java
@@ -28,12 +28,12 @@ public class Broadcaster {
                 String address = be.getRawMessage().getString("address");
                 String roomId = getRoomId(address);
                 if (roomId != null && roomHandler.roomExists(roomId)) {
-                    roomHandler.getRoom(roomId).getIndex().future().onComplete(ar -> {
+                    roomHandler.getRoom(roomId).getIndex(index -> {
                         // Copies envelope structure from EventBusBridgeImpl##deliverMessage
                         be.socket().write(Buffer.buffer(new JsonObject()
                                 .put("type", "rec")
                                 .put("address", address)
-                                .put("body", ar.result())
+                                .put("body", index)
                                 .encode()
                         ));
                     });

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
@@ -26,7 +26,7 @@ public class PurgeTask {
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
             CompositeFuture.all(toRemove.stream().map(roomHandler::queueRoomDeletion).collect(Collectors.toList()))
-                    .setHandler(res -> {
+                    .onComplete(res -> {
                         roomHandler.writeRooms();
                         LOGGER.info("Purged " + toRemove.size() + " rooms");
                     });

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
@@ -2,7 +2,6 @@ package edu.vanderbilt.yunyulin.speechdrop;
 
 import edu.vanderbilt.yunyulin.speechdrop.handlers.RoomHandler;
 import io.vertx.core.CompositeFuture;
-import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import lombok.AllArgsConstructor;
@@ -28,7 +27,6 @@ public class PurgeTask {
             CompositeFuture.all(
                             toRemove.stream()
                                     .map(roomHandler::queueRoomDeletion)
-                                    .map(Promise::future)
                                     .collect(Collectors.toList()))
                     .onComplete(res -> {
                         roomHandler.writeRooms();

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
@@ -1,7 +1,7 @@
 package edu.vanderbilt.yunyulin.speechdrop;
 
 import edu.vanderbilt.yunyulin.speechdrop.handlers.RoomHandler;
-import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import lombok.AllArgsConstructor;
@@ -24,7 +24,7 @@ public class PurgeTask {
                     .filter(el -> System.currentTimeMillis() - el.getValue().ctime > purgeIntervalInSeconds * 1000)
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
-            CompositeFuture.all(
+            Future.all(
                             toRemove.stream()
                                     .map(roomHandler::queueRoomDeletion)
                                     .collect(Collectors.toList()))

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
@@ -2,7 +2,7 @@ package edu.vanderbilt.yunyulin.speechdrop;
 
 import edu.vanderbilt.yunyulin.speechdrop.handlers.RoomHandler;
 import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import lombok.AllArgsConstructor;
@@ -25,7 +25,11 @@ public class PurgeTask {
                     .filter(el -> System.currentTimeMillis() - el.getValue().ctime > purgeIntervalInSeconds * 1000)
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
-            CompositeFuture.all(toRemove.stream().map(roomHandler::queueRoomDeletion).collect(Collectors.toList()))
+            CompositeFuture.all(
+                            toRemove.stream()
+                                    .map(roomHandler::queueRoomDeletion)
+                                    .map(Promise::future)
+                                    .collect(Collectors.toList()))
                     .onComplete(res -> {
                         roomHandler.writeRooms();
                         LOGGER.info("Purged " + toRemove.size() + " rooms");

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
@@ -28,7 +28,11 @@ public class PurgeTask {
             CompositeFuture.all(toRemove.stream().map(roomHandler::queueRoomDeletion).collect(Collectors.toList()))
                     .onComplete(res -> {
                         roomHandler.writeRooms();
-                        LOGGER.info("Purged " + toRemove.size() + " rooms");
+                        if (res.succeeded()) {
+                            LOGGER.info("Purged " + toRemove.size() + " rooms");
+                        } else {
+                            LOGGER.error("Failed to purge one or more rooms", res.cause());
+                        }
                     });
         };
         vertx.setPeriodic(3 * 60 * 60 * 1000, runPurge);

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/PurgeTask.java
@@ -28,11 +28,7 @@ public class PurgeTask {
             CompositeFuture.all(toRemove.stream().map(roomHandler::queueRoomDeletion).collect(Collectors.toList()))
                     .onComplete(res -> {
                         roomHandler.writeRooms();
-                        if (res.succeeded()) {
-                            LOGGER.info("Purged " + toRemove.size() + " rooms");
-                        } else {
-                            LOGGER.error("Failed to purge one or more rooms", res.cause());
-                        }
+                        LOGGER.info("Purged " + toRemove.size() + " rooms");
                     });
         };
         vertx.setPeriodic(3 * 60 * 60 * 1000, runPurge);

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/SpeechDropApplication.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/SpeechDropApplication.java
@@ -124,14 +124,9 @@ public class SpeechDropApplication {
                 sendEmptyIndex(ctx, 404);
             } else {
                 Room r = roomHandler.getRoom(roomId);
-                r.getIndex().onComplete(ar -> {
-                    if (ar.succeeded()) {
-                        ctx.response().putHeader(CONTENT_TYPE, APPLICATION_JSON).end(ar.result());
-                    } else {
-                        LOGGER.error("Failed to fetch index for room " + roomId, ar.cause());
-                        sendEmptyIndex(ctx, 500);
-                    }
-                });
+                r.getIndex().onComplete(ar ->
+                        ctx.response().putHeader(CONTENT_TYPE, APPLICATION_JSON).end(ar.result())
+                );
             }
         });
 
@@ -142,11 +137,6 @@ public class SpeechDropApplication {
             } else {
                 Room r = roomHandler.getRoom(roomId);
                 r.getFiles().onComplete(ar -> {
-                    if (ar.failed()) {
-                        LOGGER.error("Failed to gather files for room " + roomId, ar.cause());
-                        ctx.response().setStatusCode(500).end();
-                        return;
-                    }
                     Collection<File> files = ar.result();
                     String outFile = r.getData().name.trim() + ".zip";
 
@@ -174,7 +164,6 @@ public class SpeechDropApplication {
                                 writeBufferToResponse.handle(res.result());
                             } else {
                                 ctx.response().setStatusCode(500).end();
-                                LOGGER.error("Failed to archive files for room " + roomId, res.cause());
                             }
                         });
                     }
@@ -195,7 +184,6 @@ public class SpeechDropApplication {
                         ctx.response().putHeader(CONTENT_TYPE, APPLICATION_JSON_PRODUCES).end(index);
                         broadcaster.publishUpdate(r.getId(), index);
                     } else {
-                        LOGGER.warn("[" + roomId + "] Upload failed", ar.cause());
                         ctx.response().setStatusCode(400).end(
                                 new JsonObject().put("err", ar.cause().getMessage()).toString()
                         );
@@ -216,13 +204,8 @@ public class SpeechDropApplication {
                     sendEmptyIndex(ctx, 400);
                 } else {
                     r.deleteFile(Integer.parseInt(fileIndex)).onComplete(ar -> {
-                        if (ar.succeeded()) {
-                            ctx.response().putHeader(CONTENT_TYPE, APPLICATION_JSON).end(ar.result());
-                            broadcaster.publishUpdate(r.getId(), ar.result());
-                        } else {
-                            LOGGER.error("Failed to delete file in room " + roomId, ar.cause());
-                            sendEmptyIndex(ctx, 500);
-                        }
+                        ctx.response().putHeader(CONTENT_TYPE, APPLICATION_JSON).end(ar.result());
+                        broadcaster.publishUpdate(r.getId(), ar.result());
                     });
                 }
             }
@@ -247,11 +230,6 @@ public class SpeechDropApplication {
             } else {
                 Room r = roomHandler.getRoom(roomId);
                 r.getIndex().onComplete(ar -> {
-                    if (ar.failed()) {
-                        LOGGER.error("Failed to render room " + roomId, ar.cause());
-                        ctx.response().setStatusCode(500).end();
-                        return;
-                    }
                     String escapedRoomName = HTML_ESCAPER.escape(r.getData().name);
                     JsonObject configPayload = new JsonObject()
                             .put("mediaUrl", mediaUrl)

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/SpeechDropApplication.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/SpeechDropApplication.java
@@ -124,7 +124,7 @@ public class SpeechDropApplication {
                 sendEmptyIndex(ctx, 404);
             } else {
                 Room r = roomHandler.getRoom(roomId);
-                r.getIndex().onComplete(ar ->
+                r.getIndex().future().onComplete(ar ->
                         ctx.response().putHeader(CONTENT_TYPE, APPLICATION_JSON).end(ar.result())
                 );
             }
@@ -136,7 +136,7 @@ public class SpeechDropApplication {
                 ctx.response().setStatusCode(404).end();
             } else {
                 Room r = roomHandler.getRoom(roomId);
-                r.getFiles().onComplete(ar -> {
+                r.getFiles().future().onComplete(ar -> {
                     Collection<File> files = ar.result();
                     String outFile = r.getData().name.trim() + ".zip";
 
@@ -178,7 +178,7 @@ public class SpeechDropApplication {
                 ctx.response().setStatusCode(404).end(EMPTY_INDEX);
             } else {
                 Room r = roomHandler.getRoom(roomId);
-                r.handleUpload(ctx).onComplete(ar -> {
+                r.handleUpload(ctx).future().onComplete(ar -> {
                     if (ar.succeeded()) {
                         String index = ar.result();
                         ctx.response().putHeader(CONTENT_TYPE, APPLICATION_JSON_PRODUCES).end(index);
@@ -203,7 +203,7 @@ public class SpeechDropApplication {
                 if (fileIndex == null) {
                     sendEmptyIndex(ctx, 400);
                 } else {
-                    r.deleteFile(Integer.parseInt(fileIndex)).onComplete(ar -> {
+                    r.deleteFile(Integer.parseInt(fileIndex)).future().onComplete(ar -> {
                         ctx.response().putHeader(CONTENT_TYPE, APPLICATION_JSON).end(ar.result());
                         broadcaster.publishUpdate(r.getId(), ar.result());
                     });
@@ -229,7 +229,7 @@ public class SpeechDropApplication {
                 redirect(ctx, "/");
             } else {
                 Room r = roomHandler.getRoom(roomId);
-                r.getIndex().onComplete(ar -> {
+                r.getIndex().future().onComplete(ar -> {
                     String escapedRoomName = HTML_ESCAPER.escape(r.getData().name);
                     JsonObject configPayload = new JsonObject()
                             .put("mediaUrl", mediaUrl)

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/SpeechDropVerticle.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/SpeechDropVerticle.java
@@ -1,28 +1,46 @@
 package edu.vanderbilt.yunyulin.speechdrop;
 
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.impl.Utils;
 
 public class SpeechDropVerticle extends AbstractVerticle {
     public static String VERSION;
 
     @Override
-    public void start() throws Exception {
-        VERSION = Utils.readFileToString(vertx, "VERSION");
+    public void start(Promise<Void> startPromise) {
         HttpServerOptions serverOptions = new HttpServerOptions();
         serverOptions.setCompressionSupported(true);
         HttpServer httpServer = vertx.createHttpServer(serverOptions);
         Router router = Router.router(vertx);
 
-        new SpeechDropApplication(vertx, config(),
-                Utils.readFileToString(vertx, "main.html"),
-                Utils.readFileToString(vertx, "room.html"),
-                Utils.readFileToString(vertx, "about.html")
-        ).mount(router);
+        try {
+            VERSION = readFile("VERSION");
+            new SpeechDropApplication(vertx, config(),
+                    readFile("main.html"),
+                    readFile("room.html"),
+                    readFile("about.html")
+            ).mount(router);
+        } catch (Exception e) {
+            startPromise.fail(e);
+            return;
+        }
 
-        httpServer.requestHandler(router::accept).listen(config().getInteger("port"), config().getString("host"));
+        httpServer
+                .requestHandler(router)
+                .listen(config().getInteger("port"), config().getString("host"))
+                .onComplete(ar -> {
+                    if (ar.succeeded()) {
+                        startPromise.complete();
+                    } else {
+                        startPromise.fail(ar.cause());
+                    }
+                });
+    }
+
+    private String readFile(String path) {
+        return vertx.fileSystem().readFileBlocking(path).toString();
     }
 }

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/IndexHandler.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/IndexHandler.java
@@ -79,8 +79,8 @@ public class IndexHandler {
             entries.set(index, null);
             completedIndex = writeIndex();
             vertx.fileSystem().deleteRecursive(
-                    new File(uploadDirectory, Integer.toString(index)).getPath(), true, null
-            );
+                    new File(uploadDirectory, Integer.toString(index)).getPath(), true
+            ).onFailure(err -> LOGGER.error("Failed to delete uploaded file directory", err));
         } else {
             completedIndex = getIndexString();
         }
@@ -114,8 +114,8 @@ public class IndexHandler {
     private String writeIndex() {
         String indexString = getIndexString();
         vertx.fileSystem().writeFile(indexFile.getPath(),
-                Buffer.buffer(indexString),
-                null);
+                Buffer.buffer(indexString))
+                .onFailure(err -> LOGGER.error("Failed to write index file", err));
         return indexString;
     }
 

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/IndexHandler.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/IndexHandler.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.FileUpload;
@@ -33,58 +33,58 @@ public class IndexHandler {
     private List<FileEntry> entries;
     private boolean loaded = false;
 
-    public void load(Handler<IndexHandler> onComplete) {
-        vertx.fileSystem().readFile(indexFile.getPath(), res -> {
-            if (res.succeeded()) {
-                try {
-                    entries = new ArrayList<>(Arrays.asList(
-                            mapper.readValue(res.result().toString(), FileEntry[].class)
-                    ));
-                } catch (IOException e) { // This should never happen
-                    e.printStackTrace();
-                }
-            } else {
-                entries = new ArrayList<>();
-            }
-            loaded = true;
-            onComplete.handle(this);
-        });
+    public Future<IndexHandler> load() {
+        return vertx.fileSystem().readFile(indexFile.getPath())
+                .compose(buffer -> {
+                    try {
+                        entries = new ArrayList<>(Arrays.asList(
+                                mapper.readValue(buffer.toString(), FileEntry[].class)
+                        ));
+                        loaded = true;
+                        return Future.succeededFuture(this);
+                    } catch (IOException e) {
+                        return Future.failedFuture(e);
+                    }
+                })
+                .recover(err -> {
+                    entries = new ArrayList<>();
+                    loaded = true;
+                    return Future.succeededFuture(this);
+                });
     }
 
-    public void addFile(FileUpload uploadedFile, Date creationTime, Handler<String> indexHandler) {
+    public Future<String> addFile(FileUpload uploadedFile, Date creationTime) {
         checkLoad();
         LOGGER.info("[" + uploadDirectory.getName() + "] Processing upload "
                 + uploadedFile.fileName()
                 + " (" + uploadedFile.size() + ")");
-        vertx.fileSystem().mkdir(uploadDirectory.getPath(), uploadDirRes -> {
-            File destDir = new File(uploadDirectory, Integer.toString(entries.size()));
-            vertx.fileSystem().mkdir(destDir.getPath(), mkdirRes -> {
-                File dest = new File(destDir, uploadedFile.fileName());
-                vertx.fileSystem().copy(uploadedFile.uploadedFileName(), dest.getPath(),
-                        res -> {
-                            entries.add(new FileEntry(dest.getName(), creationTime.getTime()));
-                            indexHandler.handle(writeIndex());
-                        }
-                );
-            });
-        });
+        File destDir = new File(uploadDirectory, Integer.toString(entries.size()));
+        File dest = new File(destDir, uploadedFile.fileName());
+        return vertx.fileSystem()
+                .mkdirs(uploadDirectory.getPath())
+                .compose(v -> vertx.fileSystem().mkdirs(destDir.getPath()))
+                .compose(v -> vertx.fileSystem().copy(uploadedFile.uploadedFileName(), dest.getPath()))
+                .compose(v -> {
+                    entries.add(new FileEntry(dest.getName(), creationTime.getTime()));
+                    return writeIndex();
+                });
     }
 
-    public void deleteFile(int index, Handler<String> indexHandler) {
+    public Future<String> deleteFile(int index) {
         checkLoad();
         LOGGER.info("[" + uploadDirectory.getName() + "] Processing delete for index "
                 + index);
-        String completedIndex;
         if (entries.get(index) != null) {
             entries.set(index, null);
-            completedIndex = writeIndex();
-            vertx.fileSystem().deleteRecursive(
-                    new File(uploadDirectory, Integer.toString(index)).getPath(), true
-            );
-        } else {
-            completedIndex = getIndexString();
+            String dirToDelete = new File(uploadDirectory, Integer.toString(index)).getPath();
+            return writeIndex()
+                    .compose(indexString -> vertx.fileSystem()
+                            .deleteRecursive(dirToDelete)
+                            .recover(err -> Future.succeededFuture())
+                            .map(v -> indexString)
+                    );
         }
-        indexHandler.handle(completedIndex);
+        return Future.succeededFuture(getIndexString());
     }
 
     public Collection<File> getFiles() {
@@ -111,11 +111,11 @@ public class IndexHandler {
         }
     }
 
-    private String writeIndex() {
+    private Future<String> writeIndex() {
         String indexString = getIndexString();
-        vertx.fileSystem().writeFile(indexFile.getPath(),
-                Buffer.buffer(indexString));
-        return indexString;
+        return vertx.fileSystem()
+                .writeFile(indexFile.getPath(), Buffer.buffer(indexString))
+                .map(indexString);
     }
 
     private void checkLoad() {

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/IndexHandler.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/IndexHandler.java
@@ -80,7 +80,7 @@ public class IndexHandler {
             completedIndex = writeIndex();
             vertx.fileSystem().deleteRecursive(
                     new File(uploadDirectory, Integer.toString(index)).getPath(), true
-            ).onFailure(err -> LOGGER.error("Failed to delete uploaded file directory", err));
+            );
         } else {
             completedIndex = getIndexString();
         }
@@ -114,8 +114,7 @@ public class IndexHandler {
     private String writeIndex() {
         String indexString = getIndexString();
         vertx.fileSystem().writeFile(indexFile.getPath(),
-                Buffer.buffer(indexString))
-                .onFailure(err -> LOGGER.error("Failed to write index file", err));
+                Buffer.buffer(indexString));
         return indexString;
     }
 

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/RoomHandler.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/RoomHandler.java
@@ -8,7 +8,7 @@ import com.google.common.cache.LoadingCache;
 import edu.vanderbilt.yunyulin.speechdrop.SpeechDropApplication;
 import edu.vanderbilt.yunyulin.speechdrop.room.Room;
 import edu.vanderbilt.yunyulin.speechdrop.room.RoomData;
-import io.vertx.core.Promise;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import lombok.Getter;
@@ -97,15 +97,12 @@ public class RoomHandler {
         }
     }
 
-    public Promise<Void> queueRoomDeletion(String id) {
-        Promise<Void> promise = Promise.promise();
+    public Future<Void> queueRoomDeletion(String id) {
         if (dataStore.remove(id) != null) {
             roomCache.invalidate(id);
             File toDelete = new File(SpeechDropApplication.BASE_PATH, id);
-            vertx.fileSystem().deleteRecursive(toDelete.getPath(), true).onComplete(promise);
-        } else {
-            promise.complete();
+            return vertx.fileSystem().deleteRecursive(toDelete.getPath(), true);
         }
-        return promise;
+        return Future.succeededFuture();
     }
 }

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/RoomHandler.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/RoomHandler.java
@@ -8,7 +8,6 @@ import com.google.common.cache.LoadingCache;
 import edu.vanderbilt.yunyulin.speechdrop.SpeechDropApplication;
 import edu.vanderbilt.yunyulin.speechdrop.room.Room;
 import edu.vanderbilt.yunyulin.speechdrop.room.RoomData;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -98,7 +97,7 @@ public class RoomHandler {
         }
     }
 
-    public Future<Void> queueRoomDeletion(String id) {
+    public Promise<Void> queueRoomDeletion(String id) {
         Promise<Void> promise = Promise.promise();
         if (dataStore.remove(id) != null) {
             roomCache.invalidate(id);
@@ -107,6 +106,6 @@ public class RoomHandler {
         } else {
             promise.complete();
         }
-        return promise.future();
+        return promise;
     }
 }

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/RoomHandler.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/RoomHandler.java
@@ -92,8 +92,7 @@ public class RoomHandler {
     public void writeRooms() {
         try {
             vertx.fileSystem()
-                    .writeFile(roomsFile.getPath(), Buffer.buffer(mapper.writeValueAsString(dataStore)))
-                    .onFailure(err -> LOGGER.error("Failed to persist rooms metadata", err));
+                    .writeFile(roomsFile.getPath(), Buffer.buffer(mapper.writeValueAsString(dataStore)));
         } catch (JsonProcessingException e) { // This should never happen
             e.printStackTrace();
         }
@@ -104,13 +103,7 @@ public class RoomHandler {
         if (dataStore.remove(id) != null) {
             roomCache.invalidate(id);
             File toDelete = new File(SpeechDropApplication.BASE_PATH, id);
-            vertx.fileSystem().deleteRecursive(toDelete.getPath(), true).onComplete(ar -> {
-                if (ar.succeeded()) {
-                    promise.complete();
-                } else {
-                    promise.fail(ar.cause());
-                }
-            });
+            vertx.fileSystem().deleteRecursive(toDelete.getPath(), true).onComplete(promise);
         } else {
             promise.complete();
         }

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/RoomHandler.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/handlers/RoomHandler.java
@@ -101,7 +101,7 @@ public class RoomHandler {
         if (dataStore.remove(id) != null) {
             roomCache.invalidate(id);
             File toDelete = new File(SpeechDropApplication.BASE_PATH, id);
-            return vertx.fileSystem().deleteRecursive(toDelete.getPath(), true);
+            return vertx.fileSystem().deleteRecursive(toDelete.getPath());
         }
         return Future.succeededFuture();
     }

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/room/Room.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/room/Room.java
@@ -4,6 +4,7 @@ import edu.vanderbilt.yunyulin.speechdrop.SpeechDropApplication;
 import edu.vanderbilt.yunyulin.speechdrop.handlers.IndexHandler;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
@@ -42,11 +43,11 @@ public class Room {
     }
 
     public Future<String> handleUpload(RoutingContext ctx) {
-        Future<String> uploadFuture = Future.future();
+        Promise<String> uploadPromise = Promise.promise();
 
         Iterator<FileUpload> itr = ctx.fileUploads().iterator();
         if (!itr.hasNext()) {
-            uploadFuture.fail(new Exception("no_file"));
+            uploadPromise.fail(new Exception("no_file"));
         }
 
         FileUpload uploadedFile = itr.next();
@@ -54,31 +55,31 @@ public class Room {
 
         String mimeType = uploadedFile.contentType();
         if (!SpeechDropApplication.allowedMimeTypes.contains(mimeType)) {
-            uploadFuture.fail(new Exception("bad_type"));
+            uploadPromise.fail(new Exception("bad_type"));
         }
         if (uploadedFile.size() > SpeechDropApplication.maxUploadSize) {
-            uploadFuture.fail(new Exception("too_large"));
+            uploadPromise.fail(new Exception("too_large"));
         }
 
-        scheduleOperation(index -> index.addFile(uploadedFile, now, uploadFuture::complete));
-        return uploadFuture;
+        scheduleOperation(index -> index.addFile(uploadedFile, now, uploadPromise::complete));
+        return uploadPromise.future();
     }
 
     public Future<String> getIndex() {
-        Future<String> indexFuture = Future.future();
-        scheduleOperation(index -> indexFuture.complete(index.getIndexString()));
-        return indexFuture;
+        Promise<String> indexPromise = Promise.promise();
+        scheduleOperation(index -> indexPromise.complete(index.getIndexString()));
+        return indexPromise.future();
     }
 
     public Future<Collection<File>> getFiles() {
-        Future<Collection<File>> fileFuture = Future.future();
-        scheduleOperation(index -> fileFuture.complete(index.getFiles()));
-        return fileFuture;
+        Promise<Collection<File>> filesPromise = Promise.promise();
+        scheduleOperation(index -> filesPromise.complete(index.getFiles()));
+        return filesPromise.future();
     }
 
     public Future<String> deleteFile(int fileIndex) {
-        Future<String> deleteFuture = Future.future();
-        scheduleOperation(index -> index.deleteFile(fileIndex, deleteFuture::complete));
-        return deleteFuture;
+        Promise<String> deletePromise = Promise.promise();
+        scheduleOperation(index -> index.deleteFile(fileIndex, deletePromise::complete));
+        return deletePromise.future();
     }
 }

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/room/Room.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/room/Room.java
@@ -48,7 +48,6 @@ public class Room {
         Iterator<FileUpload> itr = ctx.fileUploads().iterator();
         if (!itr.hasNext()) {
             uploadPromise.fail(new Exception("no_file"));
-            return uploadPromise.future();
         }
 
         FileUpload uploadedFile = itr.next();
@@ -57,11 +56,9 @@ public class Room {
         String mimeType = uploadedFile.contentType();
         if (!SpeechDropApplication.allowedMimeTypes.contains(mimeType)) {
             uploadPromise.fail(new Exception("bad_type"));
-            return uploadPromise.future();
         }
         if (uploadedFile.size() > SpeechDropApplication.maxUploadSize) {
             uploadPromise.fail(new Exception("too_large"));
-            return uploadPromise.future();
         }
 
         scheduleOperation(index -> index.addFile(uploadedFile, now, uploadPromise::complete));

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/room/Room.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/room/Room.java
@@ -2,7 +2,6 @@ package edu.vanderbilt.yunyulin.speechdrop.room;
 
 import edu.vanderbilt.yunyulin.speechdrop.SpeechDropApplication;
 import edu.vanderbilt.yunyulin.speechdrop.handlers.IndexHandler;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -42,7 +41,7 @@ public class Room {
         }
     }
 
-    public Future<String> handleUpload(RoutingContext ctx) {
+    public Promise<String> handleUpload(RoutingContext ctx) {
         Promise<String> uploadPromise = Promise.promise();
 
         Iterator<FileUpload> itr = ctx.fileUploads().iterator();
@@ -62,24 +61,24 @@ public class Room {
         }
 
         scheduleOperation(index -> index.addFile(uploadedFile, now, uploadPromise::complete));
-        return uploadPromise.future();
+        return uploadPromise;
     }
 
-    public Future<String> getIndex() {
+    public Promise<String> getIndex() {
         Promise<String> indexPromise = Promise.promise();
         scheduleOperation(index -> indexPromise.complete(index.getIndexString()));
-        return indexPromise.future();
+        return indexPromise;
     }
 
-    public Future<Collection<File>> getFiles() {
+    public Promise<Collection<File>> getFiles() {
         Promise<Collection<File>> filesPromise = Promise.promise();
         scheduleOperation(index -> filesPromise.complete(index.getFiles()));
-        return filesPromise.future();
+        return filesPromise;
     }
 
-    public Future<String> deleteFile(int fileIndex) {
+    public Promise<String> deleteFile(int fileIndex) {
         Promise<String> deletePromise = Promise.promise();
         scheduleOperation(index -> index.deleteFile(fileIndex, deletePromise::complete));
-        return deletePromise.future();
+        return deletePromise;
     }
 }

--- a/src/main/java/edu/vanderbilt/yunyulin/speechdrop/room/Room.java
+++ b/src/main/java/edu/vanderbilt/yunyulin/speechdrop/room/Room.java
@@ -48,6 +48,7 @@ public class Room {
         Iterator<FileUpload> itr = ctx.fileUploads().iterator();
         if (!itr.hasNext()) {
             uploadPromise.fail(new Exception("no_file"));
+            return uploadPromise.future();
         }
 
         FileUpload uploadedFile = itr.next();
@@ -56,9 +57,11 @@ public class Room {
         String mimeType = uploadedFile.contentType();
         if (!SpeechDropApplication.allowedMimeTypes.contains(mimeType)) {
             uploadPromise.fail(new Exception("bad_type"));
+            return uploadPromise.future();
         }
         if (uploadedFile.size() > SpeechDropApplication.maxUploadSize) {
             uploadPromise.fail(new Exception("too_large"));
+            return uploadPromise.future();
         }
 
         scheduleOperation(index -> index.addFile(uploadedFile, now, uploadPromise::complete));


### PR DESCRIPTION
## Summary
- upgrade the Maven build to target JDK 17 and use the Vert.x 4.5.9 stack with explicit Jackson dependencies
- adapt verticles and handlers to Vert.x 4 callback APIs while keeping the existing callback-driven flow for room management
- update the SockJS bridge and HTTP bootstrap logic for the Vert.x 4 web layer

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68d41cab439483228df1c6e248c9aa85